### PR TITLE
Add info about node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Make sure you have python, curl, Node.js and unzip installed (see Dockerfile for
 the full list of dependencies), and then run install script to setup an isolated
 environment for the development.
 
+Note: You need version 18.18 of Node.js. This is easiest to get using Node Version Manager https://github.com/nvm-sh/nvm and then run
+
+```
+nvm install 18.18
+nvm use 18.18
+```
+
 ```
 ./scripts/install.sh
 ```


### PR DESCRIPTION
Since I had to setup the dev environment on a new computer I went again through the pain of WSL first installing node version 16.x and then trying latest 21.x with both failing until I remembered you need specifially 18.18, all other versions will fail.